### PR TITLE
`--label` -> `--annotation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ bypass4netns is experimentally integrated into nerdctl (>= 0.17.0).
 
 ```bash
 containerd-rootless-setuptool.sh install-bypass4netnsd
-nerdctl run -it --rm -p 8080:80 --label nerdctl/bypass4netns=true alpine
+nerdctl run -it --rm -p 8080:80 --annotation nerdctl/bypass4netns=true alpine
 ```
 
-NOTE: `--label nerdctl/bypass4netns=true` will be probably replaced with `--security-opt` or something like `--network-opt` in a future version of nerdctl.
+NOTE: nerdctl prior to v2.0 needs `--label` instead of `--annotation`.
+Also, the syntax will be probably replaced with `--security-opt` or something like `--network-opt` in a future version of nerdctl.
 
 ## :warning: Caveats :warning:
 Accesses to host abstract sockets and host loopback IPs (127.0.0.0/8) from containers are designed to be rejected.

--- a/benchmark/block/block.sh
+++ b/benchmark/block/block.sh
@@ -128,8 +128,8 @@ echo "===== Benchmark: block client(w/ bypass4netns) server(w/ bypass4netns) via
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name block-server -p 8080:80 -v $(pwd):/var/www/html:ro $IMAGE_NAME nginx -g "daemon off;"
-  nerdctl run --label nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name block-server -p 8080:80 -v $(pwd):/var/www/html:ro $IMAGE_NAME nginx -g "daemon off;"
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity
   LOG_NAME="block-w-b4ns.log"
   sleep 5
   rm -f $LOG_NAME
@@ -157,8 +157,8 @@ echo "===== Benchmark: block client(w/ bypass4netns) server(w/ bypass4netns) wit
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name block-server -p 8080:80 -v $(pwd):/var/www/html:ro $IMAGE_NAME nginx -g "daemon off;"
-  nerdctl run --label nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name block-server -p 8080:80 -v $(pwd):/var/www/html:ro $IMAGE_NAME nginx -g "daemon off;"
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity
   SERVER_IP=$(nerdctl exec block-server hostname -i)
   for BLOCK_SIZE in ${BLOCK_SIZES[@]}
   do

--- a/benchmark/block/block_multinode.sh
+++ b/benchmark/block/block_multinode.sh
@@ -77,9 +77,9 @@ echo "===== Benchmark: block client(w/ bypass4netns) server(w/ bypass4netns) wit
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -p 8080:80 -d --name block-server -v /home/ubuntu/bypass4netns/benchmark/block:/var/www/html:ro $IMAGE_NAME nginx -g \"daemon off;\""
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -p 8080:80 -d --name block-server -v /home/ubuntu/bypass4netns/benchmark/block:/var/www/html:ro $IMAGE_NAME nginx -g \"daemon off;\""
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec block-server hostname -i)
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name block-client $IMAGE_NAME sleep infinity"
   LOG_NAME="block-multinode-w-b4ns.log"
   rm -f $LOG_NAME
   for BLOCK_SIZE in ${BLOCK_SIZES[@]}

--- a/benchmark/etcd/etcd.sh
+++ b/benchmark/etcd/etcd.sh
@@ -112,10 +112,10 @@ echo "===== Benchmark: etcd client(w/ bypass4netns) server(w/ bypass4netns) via 
   set -ex
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name etcd-server -p 12379:2379 $ETCD_IMAGE /usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$HOST_IP:2379
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name etcd-server -p 12379:2379 $ETCD_IMAGE /usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$HOST_IP:2379
   sleep 5
   LOG_NAME="etcd-w-b4ns.log"
-  nerdctl run --label nerdctl/bypass4netns=true --rm $BENCH_IMAGE /bench put --key-size=8 --val-size=256 --conns=10 --clients=10 --total=100000 --endpoints $HOST_IP:12379 > $LOG_NAME
+  nerdctl run --annotation nerdctl/bypass4netns=true --rm $BENCH_IMAGE /bench put --key-size=8 --val-size=256 --conns=10 --clients=10 --total=100000 --endpoints $HOST_IP:12379 > $LOG_NAME
 
   nerdctl rm -f etcd-server
   nerdctl rm -f etcd-client
@@ -136,11 +136,11 @@ echo "===== Benchmark: etcd client(w/ bypass4netns) server(w/ bypass4netns) with
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name etcd-server -p 12379:2379 $ETCD_IMAGE /bin/sh -c "sleep infinity"
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name etcd-server -p 12379:2379 $ETCD_IMAGE /bin/sh -c "sleep infinity"
   sleep 5
   SERVER_IP=$(nerdctl exec etcd-server hostname -i)
   systemd-run --user --unit etcd-server nerdctl exec etcd-server /usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$SERVER_IP:2379
-  nerdctl run --label nerdctl/bypass4netns=true --rm $BENCH_IMAGE /bench put --key-size=8 --val-size=256 --conns=10 --clients=10 --total=100000 --endpoints $SERVER_IP:2379
+  nerdctl run --annotation nerdctl/bypass4netns=true --rm $BENCH_IMAGE /bench put --key-size=8 --val-size=256 --conns=10 --clients=10 --total=100000 --endpoints $SERVER_IP:2379
 
   nerdctl rm -f etcd-server
   nerdctl rm -f etcd-client

--- a/benchmark/etcd/etcd_multinode.sh
+++ b/benchmark/etcd/etcd_multinode.sh
@@ -77,10 +77,10 @@ echo "===== Benchmark: etcd client(w/ bypass4netns) server(w/ bypass4netns) with
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -p 12379:2379 --name etcd-server -d $ETCD_IMAGE /bin/sh -c 'sleep infinity'"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -p 12379:2379 --name etcd-server -d $ETCD_IMAGE /bin/sh -c 'sleep infinity'"
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec etcd-server hostname -i)
   NAME="test" exec_lxc systemd-run --user --unit etcd-server nerdctl exec etcd-server /usr/local/bin/etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls http://$SERVER_IP:2379
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true --name etcd-client -d $BENCH_IMAGE /bin/sh -c 'sleep infinity'"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true --name etcd-client -d $BENCH_IMAGE /bin/sh -c 'sleep infinity'"
   sleep 5
   LOG_NAME="etcd-multinode-w-b4ns.log"
   NAME="test2" exec_lxc nerdctl exec etcd-client /bench put --key-size=8 --val-size=256 --conns=10 --clients=10 --total=100000 --endpoints $SERVER_IP:2379 > $LOG_NAME

--- a/benchmark/iperf3/iperf3.sh
+++ b/benchmark/iperf3/iperf3.sh
@@ -125,9 +125,9 @@ echo "===== Benchmark: iperf3 client(w/ bypass4netns) server(w/ bypass4netns) vi
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name iperf3-server -p 5202:5201 $ALPINE_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name iperf3-server -p 5202:5201 $ALPINE_IMAGE sleep infinity
   nerdctl exec iperf3-server apk add --no-cache iperf3
-  nerdctl run --label nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity
   nerdctl exec iperf3-client apk add --no-cache iperf3
 
   systemd-run --user --unit iperf3-server nerdctl exec iperf3-server iperf3 -s
@@ -156,9 +156,9 @@ echo "===== Benchmark: iperf3 client(w/ bypass4netns) server(w/ bypass4netns) wi
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name iperf3-server -p 5202:5201 $ALPINE_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name iperf3-server -p 5202:5201 $ALPINE_IMAGE sleep infinity
   nerdctl exec iperf3-server apk add --no-cache iperf3
-  nerdctl run --label nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity
   nerdctl exec iperf3-client apk add --no-cache iperf3
 
   systemd-run --user --unit iperf3-server nerdctl exec iperf3-server iperf3 -s

--- a/benchmark/iperf3/iperf3_host.sh
+++ b/benchmark/iperf3/iperf3_host.sh
@@ -23,7 +23,7 @@ echo "===== Benchmark: netns -> host With bypass4netns ====="
   # start bypass4netnsd for nerdctl integration
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd
   sleep 1
-  nerdctl run --label nerdctl/bypass4netns=true -d --name test "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name test "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test apk add --no-cache iperf3
   nerdctl exec test iperf3 -c $HOST_IP
   nerdctl rm -f test
@@ -49,7 +49,7 @@ echo "===== Benchmark: host -> netns With bypass4netns ====="
   systemctl --user reset-failed
   set -ex
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name test -p 8080:5201 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name test -p 8080:5201 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test apk add --no-cache iperf3
   systemd-run --user --unit run-iperf3-netns nerdctl exec test iperf3 -s -4
   sleep 1 # waiting `iperf3 -s -4` becomes ready

--- a/benchmark/iperf3/iperf3_multinode.sh
+++ b/benchmark/iperf3/iperf3_multinode.sh
@@ -67,9 +67,9 @@ echo "===== Benchmark: iperf3 client(w/ bypass4netns) server(w/ bypass4netns) wi
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d -p 5202:5201 --name iperf3-server $ALPINE_IMAGE sleep infinity"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d -p 5202:5201 --name iperf3-server $ALPINE_IMAGE sleep infinity"
   NAME="test" exec_lxc nerdctl exec iperf3-server apk add --no-cache iperf3
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name iperf3-client $ALPINE_IMAGE sleep infinity"
   NAME="test2" exec_lxc nerdctl exec iperf3-client apk add --no-cache iperf3
 
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec iperf3-server hostname -i)

--- a/benchmark/memcached/memcached.sh
+++ b/benchmark/memcached/memcached.sh
@@ -96,9 +96,9 @@ echo "===== Benchmark: memcached client(w/ bypass4netns) server(w/ bypass4netns)
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name memcached-server -p 11212:11211 $MEMCACHED_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name memcached-server -p 11212:11211 $MEMCACHED_IMAGE
   LOG_NAME="memcached-w-b4ns.log"
-  nerdctl run --label nerdctl/bypass4netns=true -d --name memcached-client --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c "sleep infinity"
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name memcached-client --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c "sleep infinity"
   nerdctl exec memcached-client memtier_benchmark --host=$HOST_IP --port=11212 --protocol=memcache_binary --json-out-file=/$LOG_NAME > /dev/null
   nerdctl cp memcached-client:/$LOG_NAME ./$LOG_NAME
 
@@ -122,9 +122,9 @@ echo "===== Benchmark: memcached client(w/ bypass4netns) server(w/ bypass4netns)
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name memcached-server -p 11212:11211 $MEMCACHED_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name memcached-server -p 11212:11211 $MEMCACHED_IMAGE
   SERVER_IP=$(nerdctl exec memcached-server hostname -i)
-  nerdctl run --label nerdctl/bypass4netns=true -d --name memcached-client --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c "sleep infinity"
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name memcached-client --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c "sleep infinity"
   nerdctl exec memcached-client memtier_benchmark --host=$SERVER_IP --port=11211 --protocol=memcache_binary
 
   nerdctl rm -f memcached-server

--- a/benchmark/memcached/memcached_multinode.sh
+++ b/benchmark/memcached/memcached_multinode.sh
@@ -68,8 +68,8 @@ echo "===== Benchmark: memcached client(w/ bypass4netns) server(w/ bypass4netns)
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -p 11212:11211 --name memcached-server -d $MEMCACHED_IMAGE"
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true --name memcached-client -d --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c 'sleep infinity'"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -p 11212:11211 --name memcached-server -d $MEMCACHED_IMAGE"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true --name memcached-client -d --entrypoint '' $MEMTIRE_IMAGE /bin/sh -c 'sleep infinity'"
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec memcached-server hostname -i)
   sleep 5
   LOG_NAME="memcached-multinode-w-b4ns.log"

--- a/benchmark/mysql/mysql.sh
+++ b/benchmark/mysql/mysql.sh
@@ -107,8 +107,8 @@ echo "===== Benchmark: mysql client(w/ bypass4netns) server(w/ bypass4netns) via
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity
   sleep 30
   nerdctl exec mysql-client sysbench --threads=4 --time=60 --mysql-host=$HOST_IP --mysql-port=13306 --mysql-db=bench --mysql-user=root --mysql-password=pass --db-driver=mysql oltp_common prepare
   nerdctl exec mysql-client sysbench --threads=4 --time=60 --mysql-host=$HOST_IP --mysql-port=13306 --mysql-db=bench --mysql-user=root --mysql-password=pass --db-driver=mysql oltp_read_write run > mysql-w-b4ns.log
@@ -131,8 +131,8 @@ echo "===== Benchmark: mysql client(w/ bypass4netns) server(w/ bypass4netns) wit
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity
   SERVER_IP=$(nerdctl inspect mysql-server | jq -r .[0].NetworkSettings.Networks.'"unknown-eth0"'.IPAddress)
   sleep 30
   nerdctl exec mysql-client sysbench --threads=4 --time=60 --mysql-host=$SERVER_IP --mysql-port=3306 --mysql-db=bench --mysql-user=root --mysql-password=pass --db-driver=mysql oltp_common prepare

--- a/benchmark/mysql/mysql_multinode.sh
+++ b/benchmark/mysql/mysql_multinode.sh
@@ -75,8 +75,8 @@ echo "===== Benchmark: mysql client(w/ bypass4netns) server(w/ bypass4netns) wit
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE"
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d -p 13306:3306 --name mysql-server -e MYSQL_ROOT_PASSWORD=pass -e MYSQL_DATABASE=bench $MYSQL_IMAGE"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name mysql-client $BENCH_IMAGE sleep infinity"
   SERVER_IP=$(NAME="test" exec_lxc nerdctl inspect mysql-server | jq -r .[0].NetworkSettings.Networks.'"unknown-eth0"'.IPAddress)
   sleep 30
   NAME="test2" exec_lxc nerdctl exec mysql-client sysbench --threads=4 --time=60 --mysql-host=$SERVER_IP --mysql-db=bench --mysql-user=root --mysql-password=pass --db-driver=mysql oltp_common prepare

--- a/benchmark/postgres/postgres.sh
+++ b/benchmark/postgres/postgres.sh
@@ -95,8 +95,8 @@ echo "===== Benchmark: postgresql client(w/ bypass4netns) server(w/ bypass4netns
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity
   PID=$(nerdctl inspect psql-client | jq '.[0].State.Pid')
   NAME="psql-client" exec_netns /bin/bash -c "until nc -z $HOST_IP 15432; do sleep 1; done"
   nerdctl exec psql-client pgbench -h $HOST_IP -p 15432 -U postgres -s 10 -i postgres
@@ -120,8 +120,8 @@ echo "===== Benchmark: postgres client(w/ bypass4netns) server(w/ bypass4netns) 
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity
   SERVER_IP=$(nerdctl exec psql-server hostname -i)
   sleep 5
   nerdctl exec psql-client pgbench -h $SERVER_IP -p 5432 -U postgres -s 10 -i postgres

--- a/benchmark/postgres/postgres_multinode.sh
+++ b/benchmark/postgres/postgres_multinode.sh
@@ -62,8 +62,8 @@ echo "===== Benchmark: postgresql client(w/ bypass4netns) server(w/ bypass4netns
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE"
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d -p 15432:5432 --name psql-server -e POSTGRES_PASSWORD=pass $POSTGRES_IMAGE"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name psql-client -e PGPASSWORD=pass $POSTGRES_IMAGE sleep infinity"
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec psql-server hostname -i)
   sleep 5
   NAME="test2" exec_lxc nerdctl exec psql-client pgbench -h $SERVER_IP -U postgres -s 10 -i postgres

--- a/benchmark/rabbitmq/rabbitmq.sh
+++ b/benchmark/rabbitmq/rabbitmq.sh
@@ -85,10 +85,10 @@ echo "===== Benchmark: rabbitmq client(w/ bypass4netns) server(w/ bypass4netns) 
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name rabbitmq-server -p 5673:5672 $RABBITMQ_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name rabbitmq-server -p 5673:5672 $RABBITMQ_IMAGE
   sleep 10
   LOG_NAME="rabbitmq-w-b4ns.log"
-  nerdctl run --label nerdctl/bypass4netns=true --name rabbitmq-client --rm $PERF_IMAGE --uri amqp://$HOST_IP:5673 --producers 2 --consumers 2 --time 60 > $LOG_NAME
+  nerdctl run --annotation nerdctl/bypass4netns=true --name rabbitmq-client --rm $PERF_IMAGE --uri amqp://$HOST_IP:5673 --producers 2 --consumers 2 --time 60 > $LOG_NAME
 
   nerdctl rm -f rabbitmq-server
   systemctl --user stop run-bypass4netnsd
@@ -107,10 +107,10 @@ echo "===== Benchmark: rabbitmq client(w/ bypass4netns) server(w/ bypass4netns) 
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d --name rabbitmq-server -p 5673:5672 $RABBITMQ_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name rabbitmq-server -p 5673:5672 $RABBITMQ_IMAGE
   sleep 10
   SERVER_IP=$(nerdctl exec rabbitmq-server hostname -i)
-  nerdctl run --label nerdctl/bypass4netns=true --name rabbitmq-client --rm $PERF_IMAGE --uri amqp://$SERVER_IP --producers 2 --consumers 2 --time 60
+  nerdctl run --annotation nerdctl/bypass4netns=true --name rabbitmq-client --rm $PERF_IMAGE --uri amqp://$SERVER_IP --producers 2 --consumers 2 --time 60
 
   nerdctl rm -f rabbitmq-server
   systemctl --user stop run-bypass4netnsd

--- a/benchmark/rabbitmq/rabbitmq_multinode.sh
+++ b/benchmark/rabbitmq/rabbitmq_multinode.sh
@@ -68,8 +68,8 @@ echo "===== Benchmark: rabbitmq client(w/ bypass4netns) server(w/ bypass4netns) 
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -p 5673:5672 --name rabbitmq-server -d $RABBITMQ_IMAGE"
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true --name rabbitmq-client -d --entrypoint '' $PERF_IMAGE /bin/sh -c 'sleep infinity'"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -p 5673:5672 --name rabbitmq-server -d $RABBITMQ_IMAGE"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true --name rabbitmq-client -d --entrypoint '' $PERF_IMAGE /bin/sh -c 'sleep infinity'"
   sleep 5
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec rabbitmq-server hostname -i)
   LOG_NAME="rabbitmq-multinode-w-b4ns.log"

--- a/benchmark/redis/redis.sh
+++ b/benchmark/redis/redis.sh
@@ -89,8 +89,8 @@ echo "===== Benchmark: redis client(w/ bypass4netns) server(w/ bypass4netns) via
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd 
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity
   nerdctl exec redis-client redis-benchmark -q -h $HOST_IP -p 6380 --csv > redis-w-b4ns.log
   cat redis-w-b4ns.log
 
@@ -112,8 +112,8 @@ echo "===== Benchmark: redis client(w/ bypass4netns) server(w/ bypass4netns) wit
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$HOST_IP:2379 --advertise-client-urls http://$HOST_IP:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP
 
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE
-  nerdctl run --label nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE
+  nerdctl run --annotation nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity
   SERVER_IP=$(nerdctl exec redis-server hostname -i)
   # without 'sleep 1', benchmark is not performed.(race condition?)
   nerdctl exec redis-client /bin/sh -c "sleep 1 && redis-benchmark -q -h $SERVER_IP -p 6379 --csv" 

--- a/benchmark/redis/redis_multinode.sh
+++ b/benchmark/redis/redis_multinode.sh
@@ -58,9 +58,9 @@ echo "===== Benchmark: redis client(w/ bypass4netns) server(w/ bypass4netns) wit
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d -p 6380:6379 --name redis-server $REDIS_IMAGE"
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec redis-server hostname -i)
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name redis-client $REDIS_IMAGE sleep infinity"
   NAME="test2" exec_lxc nerdctl exec redis-client /bin/sh -c "sleep 1 && redis-benchmark -q -h $SERVER_IP --csv" > redis-multinode-w-b4ns.log
 
   NAME="test" exec_lxc nerdctl rm -f redis-server

--- a/test/init_test.sh
+++ b/test/init_test.sh
@@ -13,7 +13,7 @@ if [ "$(whoami)" != "$TEST_USER" ]; then
 fi
 
 GO_VERSION="1.22.0"
-NERDCTL_VERSION="2.0.0-beta.1"
+NERDCTL_VERSION="2.0.0-beta.3"
 
 echo "===== Prepare ====="
 (

--- a/test/multinode.sh
+++ b/test/multinode.sh
@@ -45,11 +45,11 @@ echo "===== Benchmark: iperf3 client(w/ bypass4netns) server(w/ bypass4netns) wi
   NAME="test" exec_lxc systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://$TEST_ADDR:2379 --advertise-client-urls http://$TEST_ADDR:2379
   NAME="test" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST_ADDR
   NAME="test2" exec_lxc systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$TEST_ADDR:2379 --multinode-host-address=$TEST2_ADDR
-  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d -p 8080:5201 --name vxlan $ALPINE_IMAGE sleep infinity"
+  NAME="test" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d -p 8080:5201 --name vxlan $ALPINE_IMAGE sleep infinity"
   NAME="test" exec_lxc nerdctl exec vxlan apk add --no-cache iperf3
   NAME="test" exec_lxc systemd-run --user --unit run-test-iperf3 nerdctl exec vxlan iperf3 -s
   SERVER_IP=$(NAME="test" exec_lxc nerdctl exec vxlan hostname -i)
-  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --label nerdctl/bypass4netns=true -d --name vxlan $ALPINE_IMAGE sleep infinity"
+  NAME="test2" exec_lxc /bin/bash -c "sleep 3 && nerdctl run --annotation nerdctl/bypass4netns=true -d --name vxlan $ALPINE_IMAGE sleep infinity"
   NAME="test2" exec_lxc nerdctl exec vxlan apk add --no-cache iperf3
   NAME="test2" exec_lxc nerdctl exec vxlan iperf3 -c $SERVER_IP
 

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -132,12 +132,12 @@ echo "===== tracer test (disabled) ====="
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --handle-c2c-connections=true
   sleep 1
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test1 apk add --no-cache iperf3
   TEST1_ADDR=$(nerdctl exec test1 hostname -i)
   systemd-run --user --unit run-test1-iperf3 nerdctl exec test1 iperf3 -s
   nerdctl network create --subnet "10.4.1.0/24" net-2
-  nerdctl run --net net-2 --label nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --net net-2 --annotation nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test2 apk add --no-cache iperf3
   nerdctl exec test2 iperf3 -c $TEST1_ADDR -t 1 --connect-timeout 1000 # it must success to connect.
 
@@ -159,12 +159,12 @@ echo "===== tracer test (enabled) ====="
 
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --handle-c2c-connections=true --tracer=true --debug
   sleep 1
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test1 apk add --no-cache iperf3
   TEST1_ADDR=$(nerdctl exec test1 hostname -i)
   systemd-run --user --unit run-test1-iperf3 nerdctl exec test1 iperf3 -s
   nerdctl network create --subnet "10.4.1.0/24" net-2
-  nerdctl run --net net-2 --label nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --net net-2 --annotation nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test2 apk add --no-cache iperf3
   set +e
   nerdctl exec test2 iperf3 -c $TEST1_ADDR -t 1 --connect-timeout 1000 # it must not success to connect.
@@ -195,12 +195,12 @@ echo "===== multinode test (single node) ===="
   systemd-run --user --unit etcd.service /usr/bin/etcd --listen-client-urls http://${HOST_IP}:2379 --advertise-client-urls http://${HOST_IP}:2379
   systemd-run --user --unit run-bypass4netnsd bypass4netnsd --multinode=true --multinode-etcd-address=http://$HOST_IP:2379 --multinode-host-address=$HOST_IP --debug
   sleep 1
-  nerdctl run --label nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --annotation nerdctl/bypass4netns=true -d -p 8080:5201 --name test1 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test1 apk add --no-cache iperf3
   TEST1_ADDR=$(nerdctl exec test1 hostname -i)
   systemd-run --user --unit run-test1-iperf3 nerdctl exec test1 iperf3 -s
   nerdctl network create --subnet "10.4.1.0/24" net-2
-  nerdctl run --net net-2 --label nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
+  nerdctl run --net net-2 --annotation nerdctl/bypass4netns=true -d --name test2 "${ALPINE_IMAGE}" sleep infinity
   nerdctl exec test2 apk add --no-cache iperf3
   nerdctl exec test2 iperf3 -c $TEST1_ADDR -t 1 --connect-timeout 1000 # it must success to connect.
 


### PR DESCRIPTION
`--label nerdctl/bypass4netns=true` was deprecated in favor of `--annotation nerdctl/bypass4netns=true` in nerdctl v2.0.0-beta.3

https://github.com/containerd/nerdctl/releases/tag/v2.0.0-beta.3

Fix #62