### PR TITLE
Add `--ignore-bind` (`bind` is already fast without bypassing)

### DIFF
--- a/cmd/bypass4netns/main.go
+++ b/cmd/bypass4netns/main.go
@@ -59,6 +59,7 @@ func main() {
 	handleC2cEnable := flag.Bool("handle-c2c-connections", false, "Handle connections between containers")
 	tracerEnable := flag.Bool("tracer", false, "Enable connection tracer")
 	multinodeEnable := flag.Bool("multinode", false, "Enable multinode communication")
+	ignoreBind := flag.Bool("ignore-bind", false, "Disable bypassing bind")
 
 	// Parse arguments
 	flag.Parse()
@@ -154,7 +155,7 @@ func main() {
 
 	logrus.Infof("SocketPath: %s", socketFile)
 
-	handler := bypass4netns.NewHandler(socketFile, comSocketFile, strings.Replace(logFilePath, ".log", "-tracer.log", -1))
+	handler := bypass4netns.NewHandler(socketFile, comSocketFile, strings.Replace(logFilePath, ".log", "-tracer.log", -1), *ignoreBind)
 
 	subnets := []net.IPNet{}
 	var subnetsAuto bool

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,6 +13,7 @@ type BypassSpec struct {
 	LogFilePath   string     `json:"logFilePath"`
 	PortMapping   []PortSpec `json:"portMapping"`
 	IgnoreSubnets []string   `json:"ignoreSubnets"` // CIDR or "auto"
+	IgnoreBind    bool       `json:"ignoreBind"`
 }
 
 type PortSpec struct {

--- a/pkg/bypass4netnsd/bypass4netnsd.go
+++ b/pkg/bypass4netnsd/bypass4netnsd.go
@@ -87,6 +87,10 @@ func (d *Driver) StartBypass(spec *api.BypassSpec) (*api.BypassStatus, error) {
 		b4nnArgs = append(b4nnArgs, fmt.Sprintf("--ignore=%s", subnet))
 	}
 
+	if spec.IgnoreBind {
+		b4nnArgs = append(b4nnArgs, "--ignore-bind")
+	}
+
 	b4nnArgs = append(b4nnArgs, fmt.Sprintf("--com-socket=%s", d.ComSocketPath))
 	if d.HandleC2CEnable {
 		b4nnArgs = append(b4nnArgs, "--handle-c2c-connections")


### PR DESCRIPTION
Workaround for:
- #65

This flag disables the acceleration for `bind` syscalls, as the current hook is not robust enough for `bind` with complicated setup.

Anyway, the performance of `bind` is not really problematic so far in the plain Rootless Containers. So we can just keep enabling bypass4netns for `connect` and relevant syscalls, and call it for a day.

See the logs of RootlessKit CI:
https://github.com/rootless-containers/rootlesskit/actions/runs/8558692577/job/23453781376
- Benchmark: TCP Ports (network driver=slirp4netns, port driver=builtin): 34.8 Gbps, 34.7 Gbps
- Benchmark: TCP Ports (network driver=pasta, port driver=implicit):      39.3 Gbps, 39.2 Gbps
- Benchmark: UDP Ports (network driver=slirp4netns, port driver=builtin): 25.1 Gbps, 17.2 Gbps
- Benchmark: UDP Ports (network driver=pasta, port driver=implicit):      37.9 Gbps, 13.2 Gbps