### PR TITLE
Validate whether process belongs to the container's NetNS

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -20,8 +20,16 @@ func ShrinkID(id string) string {
 }
 
 func SameUserNS(pidX, pidY int) (bool, error) {
-	nsX := fmt.Sprintf("/proc/%d/ns/user", pidX)
-	nsY := fmt.Sprintf("/proc/%d/ns/user", pidY)
+	return sameNS(pidX, pidY, "user")
+}
+
+func SameNetNS(pidX, pidY int) (bool, error) {
+	return sameNS(pidX, pidY, "net")
+}
+
+func sameNS(pidX, pidY int, nsName string) (bool, error) {
+	nsX := fmt.Sprintf("/proc/%d/ns/%s", pidX, nsName)
+	nsY := fmt.Sprintf("/proc/%d/ns/%s", pidY, nsName)
 	nsXResolved, err := os.Readlink(nsX)
 	if err != nil {
 		return false, err

--- a/test/DockerfileNestedNetNS
+++ b/test/DockerfileNestedNetNS
@@ -1,0 +1,4 @@
+FROM ubuntu:22.04
+
+RUN apt update && apt upgrade -y
+RUN apt install -y netcat iproute2 tcpdump iperf3


### PR DESCRIPTION
bypass4netns handles all sockets in the container NetNS.
However, in the nested NetNS environment, it wrongly bypasses sockets in the nested NetNS.
It causes the following issues.
https://github.com/rootless-containers/bypass4netns/issues/65
https://github.com/rootless-containers/bypass4netns/issues/66

This patch makes bypass4netns ignore any sockets created in non-container NetNS including nested ones.